### PR TITLE
flymake-float-time -> float-time

### DIFF
--- a/tss.el
+++ b/tss.el
@@ -280,7 +280,7 @@
         (tss--debug "Start run flymake")
         (tss--sync-server)
         (setq flymake-last-change-time nil)
-        (setq flymake-check-start-time (flymake-float-time))
+        (setq flymake-check-start-time (float-time))
         (let* ((ret (tss--get-server-response "showErrors"
                                               :waitsec 2
                                               :response-start-char "["


### PR DESCRIPTION
flymake.el contained in Emacs24.4 is not defined flymake-float-time.
